### PR TITLE
fix: milgra/sov#42 CSS Colors don't follow standard #RRGGBBAA

### DIFF
--- a/src/kinetic_ui/ku_connector_wayland.c
+++ b/src/kinetic_ui/ku_connector_wayland.c
@@ -387,7 +387,7 @@ void ku_wayland_create_buffer(wl_window_t* info, int width, int height)
     info->bitmap.data = info->shm_data;
 
     struct wl_shm_pool* pool   = wl_shm_create_pool(wlc.shm, fd, size);
-    struct wl_buffer*   buffer = wl_shm_pool_create_buffer(pool, 0, width, height, stride, WL_SHM_FORMAT_ARGB8888);
+    struct wl_buffer*   buffer = wl_shm_pool_create_buffer(pool, 0, width, height, stride, WL_SHM_FORMAT_ABGR8888);
 
     wl_shm_pool_destroy(pool);
 


### PR DESCRIPTION
Although very misleading, the Wayland RGBA format appears to be actually stored as BGRA:

> WL_DRM_FORMAT_ARGB8888
>
> Always stored as B, G, R, A in memory (B at lowest address, A at highest)
Source: https://afrantzis.com/pixel-format-guide/wayland_drm.html

Compatible format between OpenGL `GL_RGBA+GL_UNSIGNED_BYTE` and `wayland_drm` family appears to be: `WL_DRM_FORMAT_ABGR8888`

    $ git clone https://github.com/afrantzis/pixel-format-guide.git
    $ cd pixel-format-guide

    $ python -m pfg find-compatible GL_RGBA+GL_UNSIGNED_BYTE wayland_drm
    Format: GL_RGBA+GL_UNSIGNED_BYTE
    Is compatible on all systems with:
            WL_DRM_FORMAT_ABGR8888
    Is compatible on little-endian systems with:
    Is compatible on big-endian systems with:

In this code, `WL_SHM` is used, so this commit uses the `SHM` variant.

Reference:

 - _"A Pixel Format Guide to the Galaxy"_, Presenter: Alexandros Frantzis, FOSDEM 2018

Video: https://www.youtube.com/watch?v=NoZwgNSuqkU
Slides: https://archive.fosdem.org/2018/schedule/event/pixel_formats/attachments/slides/2627/export/events/attachments/pixel_formats/slides/2627/fosdem_2018_pixel_format_guide.pdf

pixel-format-guide
------------------

Project Page: https://afrantzis.github.io/pixel-format-guide/
Project Repo: https://github.com/afrantzis/pixel-format-guide
Blog: https://afrantzis.wordpress.com/